### PR TITLE
Fix results page crash from loop.parent

### DIFF
--- a/docs/ISSUES.md
+++ b/docs/ISSUES.md
@@ -1,0 +1,6 @@
+# Issue Tracker
+
+This file documents notable issues and their resolutions.
+
+## Resolved
+- **2025-06-09**: Results page crashed with `UndefinedError` for `loop.parent` after Jinja upgrade. Fixed by capturing the outer loop index in a variable.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,11 @@
 import os, sys
+import http.server
+import socket
+import threading
+import functools
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 import pytest
 from webapp.app import app
 
@@ -9,6 +15,36 @@ def client():
     with app.test_client() as client:
         yield client
 
+class ThreadedHTTPServer:
+    def __init__(self, host, port, directory):
+        handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=directory)
+        self.server = http.server.ThreadingHTTPServer((host, port), handler)
+        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread.daemon = True
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.server.shutdown()
+        self.thread.join()
+
+@pytest.fixture
+def local_site(tmp_path):
+    index = tmp_path / 'index.html'
+    page2 = tmp_path / 'page2.html'
+    index.write_text('<html><body><a href="page2.html">Next</a></body></html>')
+    page2.write_text('<html><body><p>Page 2</p></body></html>')
+
+    sock = socket.socket()
+    sock.bind(("localhost", 0))
+    host, port = sock.getsockname()
+    sock.close()
+
+    with ThreadedHTTPServer(host, port, str(tmp_path)):
+        yield f"http://{host}:{port}"
+
 def test_index_route(client):
     resp = client.get('/')
     assert resp.status_code == 200
@@ -17,3 +53,9 @@ def test_index_route(client):
 def test_discover_no_urls(client):
     resp = client.post('/discover', data={'urls': ''}, follow_redirects=False)
     assert resp.status_code == 302
+
+
+def test_discover_valid_url(client, local_site):
+    resp = client.post('/discover', data={'urls': local_site})
+    assert resp.status_code == 200
+    assert b'Select links to scrape' in resp.data

--- a/webapp/templates/results.html
+++ b/webapp/templates/results.html
@@ -17,6 +17,7 @@
         <form action="{{ url_for('scrape_selected') }}" method="post">
             {% set has_discoverable_links = false %}
             {% for base_url, result in discovery_results.items() %}
+                {% set outer_index = loop.index %}
                 <div class="base-url-section">
                     <h2>Base URL: <code>{{ base_url }}</code></h2>
                     {% if result.error %}
@@ -27,7 +28,7 @@
                         <ul class="link-list">
                             {% for link in result.links %}
                                 {# Generate a unique ID for each checkbox and label pair #}
-                                {% set checkbox_id = "link_" ~ loop.parent.loop.index ~ "_" ~ loop.index %}
+                                {% set checkbox_id = "link_" ~ outer_index ~ "_" ~ loop.index %}
                                 <li>
                                     <input type="checkbox" name="selected_links" value="{{ link }}" id="{{ checkbox_id }}" checked>
                                     <label for="{{ checkbox_id }}">{{ link }}</label>


### PR DESCRIPTION
## Summary
- fix Jinja template by avoiding `loop.parent` which is unavailable in Jinja3
- track resolved issue in `docs/ISSUES.md`
- add regression test for `/discover` with a valid URL

## Testing
- `pytest -q`
- `python -m webapp.app & sleep 2; curl -I http://127.0.0.1:5000/ ; pkill -f "webapp.app"`

------
https://chatgpt.com/codex/tasks/task_e_68472daf2fcc8323b3ff34c1aaa36d01