### PR TITLE
Add gitignore for Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Python caches and compiled files
+__pycache__/
+*.py[cod]
+
+# Environment variables and virtualenvs
+.env
+.venv/
+venv/
+ENV/
+env/
+
+# Logs
+logs/
+*.log
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Miscellaneous
+*.swp
+.DS_Store
+
+# Node
+node_modules/
+


### PR DESCRIPTION
## Summary
- prevent accidental commits of Python caches and environment files by adding `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474cf0e1288323a9b131c5e44f8c9d