### PR TITLE
Add dark mode script test

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -71,3 +71,9 @@ def test_scrape_selected_footer(client, local_site):
     assert b'Developed by Artemis Applied Research 2025' in resp.data
     assert b'mode-toggle' in resp.data
     assert b'toggle-log' in resp.data
+
+
+def test_darkmode_script_served(client):
+    resp = client.get('/static/darkmode.js')
+    assert resp.status_code == 200
+    assert b'function toggleDarkMode' in resp.data


### PR DESCRIPTION
## Summary
- ensure darkmode.js is served via new integration test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847acbad7488323a92e0f184012efd2