### PR TITLE
Add live log streaming via SSE

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -77,3 +77,12 @@ def test_darkmode_script_served(client):
     resp = client.get('/static/darkmode.js')
     assert resp.status_code == 200
     assert b'function toggleDarkMode' in resp.data
+
+
+def test_logs_stream_endpoint(client, local_site):
+    links = [f"{local_site}/index.html"]
+    client.post('/scrape_selected', data={'selected_links': links})
+    resp = client.get('/logs_stream')
+    assert resp.status_code == 200
+    chunk = next(resp.response)
+    assert b'data:' in chunk

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from webapp.utils import sanitize_filename, create_session_output_directory
+from webapp.utils import sanitize_filename, create_session_output_directory, LogBufferHandler
 import os
+import logging
 
 
 def test_sanitize_filename():
@@ -12,3 +13,18 @@ def test_create_session_output_directory(tmp_path):
     d = create_session_output_directory('https://example.com', root_output_dir=tmp_path)
     assert os.path.isdir(d)
     assert str(d).startswith(str(tmp_path))
+
+
+def test_log_buffer_handler_cap_limit():
+    handler = LogBufferHandler(max_lines=10)
+    handler.setFormatter(logging.Formatter('%(message)s'))
+    test_logger = logging.getLogger('test_log_buffer')
+    test_logger.addHandler(handler)
+    test_logger.setLevel(logging.INFO)
+
+    for i in range(12):
+        test_logger.info(f'line {i}')
+
+    assert len(handler.buffer) == 10
+    assert handler.buffer[0] == 'line 2'
+    assert handler.buffer[-1] == 'line 11'

--- a/webapp/static/ui.js
+++ b/webapp/static/ui.js
@@ -27,8 +27,26 @@ function setupLogToggle() {
     });
 }
 
+function setupLogStream() {
+    const logLines = [];
+    const pre = document.getElementById('log-lines');
+    const latest = document.getElementById('latest-log');
+    if (!pre) return;
+
+    const source = new EventSource('/logs_stream');
+    source.onmessage = (e) => {
+        logLines.push(e.data);
+        if (logLines.length > 10) logLines.shift();
+        pre.textContent = logLines.join('\n');
+        if (latest) {
+            latest.textContent = logLines[logLines.length - 1];
+        }
+    };
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     setupSpinner();
     setupLogToggle();
+    setupLogStream();
 });
 

--- a/webapp/templates/scraped.html
+++ b/webapp/templates/scraped.html
@@ -74,9 +74,9 @@
 
     <div class="log-dropdown mt-6">
         <button id="toggle-log" type="button" class="mb-2 px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded">Show Logs</button>
-        <pre id="latest-log">{{ logs[-1] if logs else 'No log entries' }}</pre>
+        <pre id="latest-log">Waiting for logs...</pre>
         <div id="log-container" class="hidden">
-            <pre>{{ logs|join('\n') if logs else 'No log entries' }}</pre>
+            <pre id="log-lines"></pre>
         </div>
     </div>
 

--- a/webapp/utils.py
+++ b/webapp/utils.py
@@ -3,6 +3,7 @@ import logging
 import re
 from datetime import datetime
 from urllib.parse import urlparse
+from collections import deque
 
 # Global Logger - This might be reconfigured for Flask app context later
 logging.basicConfig(
@@ -11,6 +12,18 @@ logging.basicConfig(
     handlers=[logging.StreamHandler()]
 )
 logger = logging.getLogger(__name__)
+
+# In-memory log buffer handler for streaming last N log lines
+class LogBufferHandler(logging.Handler):
+    """Stores log records in a fixed-size deque for retrieval."""
+
+    def __init__(self, max_lines: int = 10):
+        super().__init__()
+        self.buffer = deque(maxlen=max_lines)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        msg = self.format(record)
+        self.buffer.append(msg)
 
 # Output directory can be overridden with SCRAPER_OUTPUT_DIR.
 # Default to a writable location within the container/CI environment.


### PR DESCRIPTION
## Summary
- implement `LogBufferHandler` to keep last 10 log lines
- wire handler into Flask app and expose `/logs_stream`
- update scraped template to stream logs over EventSource
- handle streaming in `ui.js`
- test new handler and endpoint

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684980bdca608323bbdd4df9a999d5c4