### PR TITLE
Add spinner status updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Web Scraper UI is a Flask-based web application that allows users to scrape text
 *   **Integrated File Management:** Filebrowser service provides easy access to view, download, and manage scraped files directly in your browser.
 *   **Dockerized:** Comes with `Dockerfile` and `docker-compose.yml` for quick and consistent setup and deployment.
 *   **Persistent Storage:** Scraped data is stored in a Docker named volume, ensuring data persistence across container restarts.
+*   **Live Status Updates:** A spinner shows short progress messages during scraping based on the latest log entries.
 
 ## Prerequisites
 

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -209,6 +209,16 @@ code {
     100% { transform: rotate(360deg); }
 }
 
+.spinner-status {
+    margin-top: 15px;
+    font-size: 1.1em;
+    color: #333;
+}
+
+.dark .spinner-status {
+    color: #eee;
+}
+
 .hidden { display: none; }
 
 /* Log Dropdown */

--- a/webapp/static/ui.js
+++ b/webapp/static/ui.js
@@ -4,8 +4,10 @@ function setupSpinner() {
     if (!form) return;
     form.addEventListener('submit', () => {
         const overlay = document.getElementById('spinner-overlay');
+        const statusEl = document.getElementById('spinner-status');
         if (overlay) {
             overlay.style.display = 'flex';
+            if (statusEl) statusEl.textContent = 'Starting...';
         }
     });
 }
@@ -31,6 +33,7 @@ function setupLogStream() {
     const logLines = [];
     const pre = document.getElementById('log-lines');
     const latest = document.getElementById('latest-log');
+    const statusEl = document.getElementById('spinner-status');
     if (!pre) return;
 
     const source = new EventSource('/logs_stream');
@@ -41,7 +44,21 @@ function setupLogStream() {
         if (latest) {
             latest.textContent = logLines[logLines.length - 1];
         }
+        if (statusEl) {
+            statusEl.textContent = parseStatus(logLines[logLines.length - 1]);
+        }
     };
+}
+
+function parseStatus(logLine) {
+    const msg = logLine.split(' - ').slice(2).join(' - ');
+    if (msg.includes('Starting link discovery')) return 'Discovering links...';
+    if (msg.includes('Found') && msg.includes('links')) return msg;
+    if (msg.includes('Starting scraping')) return 'Starting scraping...';
+    if (msg.includes('Scraping content from')) return 'Scraping pages...';
+    if (msg.includes('Saved content from')) return 'Saving page...';
+    if (msg.includes('completed')) return 'Completed.';
+    return msg;
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/webapp/templates/results.html
+++ b/webapp/templates/results.html
@@ -66,6 +66,7 @@
 </div>
 <div id="spinner-overlay" class="spinner-overlay">
     <div class="spinner"></div>
+    <div id="spinner-status" class="spinner-status">Preparing...</div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a status message next to the spinner while scraping
- parse last log line for short progress text
- style new spinner status element
- document live status updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684990a3ea6c8323ac35a6fb64d7e339